### PR TITLE
Restyle hero jump buttons and correct goals layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,48 +35,47 @@
   </header>
 
   <main id="top" class="hero">
-    <!-- Title sits high in the hero -->
+    <img src="loading-background.png" alt="Loading background" class="hero-bg" />
+    <div class="hero-content">
+      <div class="title-group">
+        <h1 class="wordmark">GOLABII</h1>
+        <!-- Tagline acts as subtext to the wordmark -->
+        <p class="tagline">All campaign profits going to relief and community causes</p>
+      </div>
 
-        <!-- Title sits high in the hero -->
-        <img src="loading-background.png" alt="Loading background" class="hero-bg" />
-        <div class="title-group">
-      <h1 class="wordmark">GOLABII</h1>
-      <!-- Tagline acts as subtext to the wordmark -->
-      <p class="tagline">All campaign profits going to relief and community causes</p>
-    </div>
+      <!-- Call‑to‑action button -->
+      <div class="cta-group">
+        <a href="#contact" class="cta-primary cta-large">Join waitlist</a>
+      </div>
 
-        <!-- Call‑to‑action button -->
-        <div class="cta-group">
-      <a href="#contact" class="cta-primary cta-large">Join waitlist</a>
-    </div>
-
-    <!-- Bottom third messaging -->
-    <div class="bottom-notice">
-      <p class="coming">coming soon to kick starter</p>
+      <!-- Bottom third messaging -->
+      <div class="bottom-notice">
+        <p class="coming">coming soon to kick starter</p>
+      </div>
     </div>
 
     <!-- Static image links. Placed after the bottom notice so they never overlay text.  -->
     <!-- Display all three scroll‑down images in a single horizontal row for a balanced, uniform layout.  -->
-    <div class="hero-links">
+    <nav class="hero-links" aria-label="Section shortcuts">
       <a href="#what-is" class="hero-link">
-        <div class="hero-img-container">
+        <span class="hero-img-container">
           <img src="infusion2.jpeg" alt="Saffron infusion jar" />
-          <span class="hero-link-text">What is it?</span>
-        </div>
+        </span>
+        <span class="hero-link-text">What is it?</span>
       </a>
       <a href="#mission" class="hero-link">
-        <div class="hero-img-container">
+        <span class="hero-img-container">
           <img src="tapestry2.jpg" alt="Floral tapestry and market" />
-          <span class="hero-link-text">Our mission</span>
-        </div>
+        </span>
+        <span class="hero-link-text">Our mission</span>
       </a>
       <a href="#goals" class="hero-link">
-        <div class="hero-img-container">
+        <span class="hero-img-container">
           <img src="cocktail2.jpeg" alt="Cocktail with saffron and rose" />
-          <span class="hero-link-text">Our goals</span>
-        </div>
+        </span>
+        <span class="hero-link-text">Our goals</span>
       </a>
-    </div>
+    </nav>
   </main>
 
   <section id="what-is" class="split">

--- a/index.html
+++ b/index.html
@@ -10,169 +10,14 @@
   <!-- Load Playfair Display font from Google Fonts for all typography -->
   <link href="https://fonts.googleapis.com/css2?family=Playfair+Display:wght@400;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="style.css" />
-      <style>
-      .hero {
-        position: relative;
-                background-image: url('loading-background.png');
-        background-size: cover;
-        
-        
-        background-position: center;
-
-      }
-      .hero-bg {
-        position: absolute;
-        top: 0;
-        left: 0;
-        width: 100%;
-        height: 100%;
-        object-fit: cover;
-        z-index: -1;        display: none;
-
-      }
-      /* Hide text groups on the hero */
-      .title-group, .cta-group, .bottom-notice {
-   }
-       display: none;
-}
-
-        
-            /* Custom nav colours and styling */
-    :root {
-      --nav-bg: rgba(90, 0, 5, 0.85);
-      --nav-color: #d4af37;
-  --button-softpink: #e5a6c2;
-  --button-softpink-hover: #dca0b8;
-    }
-
-    /* Make header text whimsical with italic styling */
-    .nav,
-    .nav .brand,
-    .nav nav,
-  c
-    .nav nav a {
-      font-style: italic;
-    }
-
-   /* Soft pink join waitlist button with reflective golden border 
-    .nav .pill {
-  background: var(--button-softpink);
-    border: 2px solid var(--nav-color);
-      color: #fff;
-       
-    }
-    }
-.nav .pill:hover {
-  background: var(--button-softpink-hover);
-  box-shadow: 0 0 12px var(--nav-color), inset 0 0 6px rgba(255, 255, 255, 0.6);
-    box-shadow: 0 0 12px var(--nav-color), inset 0 0 6px rgba(255, 255, 255, 0.6);
-
-}
-
-    /* Position hero labels above images and centre them */
-    .hero-label.top {
-      top: -1.4rem;
-      left: 50%;
-      transform: translateX(-50%);
-      text-align: center;
-      color: #e5a6c2;
-      width: 100%;
-    }
-
-  /* Mobile refinements */
-@media (max-width: 900px) {
-  .hero-links {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 12px;
-  }
-  .hero-link img {
-    width: min(30vw, 100px);
-  }
-}
- 
-      }
-   
-  
-          /* === Custom overrides === */
+  <style>
     .hero {
-      position: relative;
       background-image: url('loading-background.png');
       background-size: cover;
       background-position: center;
     }
-    .hero-bg {
-      position: absolute;
-      top: 0;
-      left: 0;
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      z-index: -1;
-      display: none;
-    }
-    /* Hide original hero title, tagline and CTA elements */
-    .title-group, .cta-group, .bottom-notice {
-      display: none;
-    }
-
-    :root {
-      --nav-bg: rgba(90, 0, 5, 0.85);
-      --nav-color: #d4af37;
-      --button-softpink: #e5a6c2;
-      --button-softpink-hover: #dca0b8;
-    }
-    /* Navigation colours and whimsical font */
-    .nav {
-      background: var(--nav-bg);
-    }
-    .nav a,
-    .nav .brand {
-      color: var(--nav-color);
-      font-style: italic;
-    }
-    /* Join waitlist button styled soft pink with gold border and dark red text */
-    .nav .pill {
-      background: var(--button-softpink);
-      border: 2px solid var(--nav-color);
-      color: #7a0e17;
-      padding: 0.4rem 1rem;
-      border-radius: 50px;
-    }
-    .nav .pill:hover {
-      background: var(--button-softpink-hover);
-      box-shadow: 0 0 12px var(--nav-color), inset 0 0 6px rgba(255, 255, 255, 0.6);
-    }
-
-    /* Position hero labels above images and center them with soft pink colour */
-    .hero-label.top {
-      position: relative;
-      top: -1.2rem;
-      left: 50%;
-      transform: translateX(-50%);
-      display: block;
-      color: #e5a6c2;
-      text-align: center;
-      font-weight: 600;
-    }
-
-    /* Responsive adjustments for hero links on small screens */
-    @media (max-width: 900px) {
-      .hero-links {
-        display: flex;
-        flex-direction: row;
-        flex-wrap: wrap;
-        justify-content: center;
-        gap: 12px;
-      }
-      .hero-link img {
-        width: min(30vw, 100px);
-      }
-    }
-</style>
-</head
+  </style>
+</head>
 <body>
   <header class="nav">
     
@@ -215,23 +60,20 @@
     <div class="hero-links">
       <a href="#what-is" class="hero-link">
         <div class="hero-img-container">
-          <span class="hero-label top">Ingredients</span>
           <img src="infusion2.jpeg" alt="Saffron infusion jar" />
-          <span class="hero-label bottom">What is it</span>
+          <span class="hero-link-text">What is it?</span>
         </div>
       </a>
       <a href="#mission" class="hero-link">
         <div class="hero-img-container">
-          <span class="hero-label top">Our mission</span>
           <img src="tapestry2.jpg" alt="Floral tapestry and market" />
-          <span class="hero-label bottom">Who we do it for</span>
+          <span class="hero-link-text">Our mission</span>
         </div>
       </a>
       <a href="#goals" class="hero-link">
         <div class="hero-img-container">
-          <span class="hero-label top">Our goals</span>
           <img src="cocktail2.jpeg" alt="Cocktail with saffron and rose" />
-          <span class="hero-label bottom">How we're going to do it</span>
+          <span class="hero-link-text">Our goals</span>
         </div>
       </a>
     </div>
@@ -270,10 +112,7 @@
 
   <!-- Goals section: outlines how we plan to achieve our vision -->
   <section id="goals" class="split">
-  
-  
-}
-<div class="copy">
+    <div class="copy">
       <h2>Our goals</h2>
       <p>Our goals describe how we'll bring Golabii to life. We plan to grow responsibly, engage our supporters and build a sustainable supply chain rooted in community.</p>
       <ul>
@@ -305,8 +144,4 @@
 
   <script src="script.js"></script>
 </body>
-    color: #e5a6c2;
-  font-weight: 600;
-  text-align: center;
-
 </html>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,4 @@
-:.nav .pill
-r.nav .pill 
-oot{
+:root{
 
   --bg:#ffffff;          /* white background */
   --ink:#0e0e0e;
@@ -31,9 +29,7 @@ html,body{
   font:16px/1.5 'Playfair Display', serif;
 }
 
-/* Enable smoot.nav .pill
-h.nav .pill
- scrolling for anchor navigation so that clicking a link animates the scroll rather than jumping */
+/* Enable smooth scrolling for anchor navigation so that clicking a link animates the scroll rather than jumping */
 html{
   scroll-behavior: smooth;
 }
@@ -82,15 +78,21 @@ button{font:inherit}
 }
 
 .nav .pill{
-  /* Elongate and emphasise the navigation join button */
-  /* Make the nav join button more elongated by increasing its horizontal padding */
   padding:8px 52px;
   border-radius:999px;
-  /* Apply a magenta‑orange gradient consistent with the hero button */
-background: #e5a6c2;
-  border: 2px solid #d4af37;
-  color: #7a0e17;
-.ber:0;font-size:20px}
+  background:#e5a6c2;
+  border:2px solid #d4af37;
+  color:#7a0e17;
+  font-size:20px;
+  font-weight:600;
+  box-shadow:0 0 12px rgba(212, 175, 55, 0.4), inset 0 0 6px rgba(255,255,255,0.6);
+  transition:transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.nav .pill:hover{
+  transform:translateY(-2px);
+  box-shadow:0 10px 20px rgba(0,0,0,0.2), 0 0 16px rgba(212, 175, 55, 0.6);
+}
 
 /* HERO LAYOUT - new grid with corner cards and high title */
 .hero{
@@ -104,6 +106,16 @@ background: #e5a6c2;
   min-height: 92svh;
   /* Move content further upward and allocate more space for the images at the bottom */
   padding: 4svh 20px 10svh;
+}
+
+.hero-bg{
+  position:absolute;
+  inset:0;
+  width:100%;
+  height:100%;
+  object-fit:cover;
+  z-index:-1;
+  filter:brightness(0.92);
 }
 
 /* Title group sits high between the top images */
@@ -167,62 +179,19 @@ background: #e5a6c2;
   font-size:clamp(18px,2.5vw,28px);
 }
 
-/* Container for the static hero links */
+/* Container for the hero jump links */
 .hero-links{
   display:flex;
-  /* Arrange all three images in a single horizontal row */
-  flex-direction:row;
+  gap:1rem;
+  align-items:center;
   justify-content:center;
-  /* Keep images aligned along their top edges */
-  align-items:flex-start;
-  /* Provide generous spacing between each image */
-  gap:48px;
-  /* Prevent wrapping on large screens so all three images remain in one row */
-  flex-wrap:nowrap;
-  /* Place the hero links below the bottom notice using normal document flow rather than absolute positioning.
-     This prevents them from overlaying other elements, especially on narrow screens. */
-  margin-top:1.5rem;
   position:relative;
-  z-index:4;
+  z-index:5;
 }
 
-/* Remove specialised columns since hero-links now displays all images in a single row */
-/* .hero-left and .hero-right definitions are no longer needed */
-
-/* Ensure uniform sizing for all hero images */
-.hero-link img{
-  /* Ensure all hero images share consistent dimensions for a clean, harmonious layout.  Use a fixed aspect
-     ratio so portraits and still‑life photographs render at the same height. */
-  width:min(26vw,260px);
-  aspect-ratio:0.75;
-  height:auto;
-  object-fit:cover;
-  border-radius:16px;
-  box-shadow:0 4px 16px rgba(0,0,0,.15);
-  transition:transform .2s ease;
+.hero-link{
+  text-decoration:none;
 }
-
-
-
-.hero-link img:hover{
-  transform:translateY(-4px);
-}
-
-/* Adjust overlay label font to use Playfair Display */
-.hero-label{
-  font-family:'Playfair Display', serif;
-}
-/* removed duplicate hero image size declarations (see above for final sizing) */
-
-/* Hero image container and overlay labels */
-.hero-img-container{
-  position:relative;
-  display:inline-block;
-  overflow:hidden;
-}
-/* legacy hero-label declaration overwritten above; font-family updated to Playfair */
-.hero-label.top{ top:0.4rem; }
-.hero-label.bottom{ bottom:0.4rem; }
 
 /* Bottom third message */
 .bottom-notice{
@@ -290,25 +259,6 @@ background: #e5a6c2;
   .card img{width:100%;min-width:0}
   .split{grid-template-columns:1fr}
   .grid{grid-template-columns:1fr}
-/* Adjust hero links on small screens: arrange horizontally with wrapping and center alignment */
-
-.hero-links{
-    flex-direction: row;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: 12px;
-    margin-top: 1rem;
-    align-items: center;
-}
-
-
-
-  /* Remove specialised column behaviour on small screens */
-  .hero-link img{
-    /* Allow the images to take nearly full width on small screens */
-        width: min(30vw, 120px);
-
-  }
 }
 
 /* Contact section with a single large call‑to‑action button */
@@ -319,117 +269,96 @@ background: #e5a6c2;
 .big-join{
   display:inline-block;
   margin-top:1.2rem;
-  /* Use the same magenta‑to‑orange gradient as other CTA buttons */
   background:linear-gradient(135deg, var(--cta-gradient-start) 0%, var(--cta-gradient-end) 100%);
   color:#fff;
   padding:22px 60px;
-  font-size:clamp(
-    22px,2.5vw,36px);
+  font-size:clamp(22px,2.5vw,36px);
   border-radius:20px;
   text-decoration:none;
   box-shadow:0 8px 18px rgba(0,0,0,.18);
 }
 .big-join:hover{
-  /* Apply the same glowing hover effect to the big join button */
   box-shadow:0 0 20px var(--cta-gradient-end, #9b111e), 0 12px 24px rgba(0,0,0,.26);
   transform:translateY(-2px);
   transition:box-shadow .3s ease, transform .3s ease;
 }
-}
 
-/* Custom hero background and hide text elements */
+/* Hero jump buttons */
 .hero {
-  background-image: url('loading-background.png');
-  background-size: cover;
-  background-position: center;
-  height: 100vh;
-}
-.hero .title-group,
-.hero .cta-group,
-.hero .bottom-notice {
-  display: none;
+  padding-bottom: 12rem;
 }
 
-
-/* Custom header colors, fonts, and join button styling */
-:root {
-  /* Darker red for the navigation bar */
-  --nav-bg: rgba(90, 0, 5, 0.85);
-  /* Metallic gold for navigation text */
-  --nav-color: #d4af37;
-}
-
-/* Make header text more whimsical by italicizing the font */
-.nav, .nav .brand, .nav nav, .nav nav a {
-  font-style: italic;
-}
-
-/* Style the join-waitlist pill button with deep red and reflective golden border */
-.nav .pill {
-  background: #9b111e;
-  border: 2px solid #d4af37;
-  background: #e5a6c2;
-  border: 2px solid #d4af37;
-  color: #7a0e17;
-  box-shadow: 0 0 8px #d4af37, inset 0 0 4px rgba(255,255,255,0.4);
-
-  box-shadow: 0 0 12px #d4af37, inset 0 0 6px rgba(255, 255, 255, 0.6);
-}
-
-/* Adjust hero label positioning and color */
-.hero-label.top {
-  top: -1.4rem;
+.hero-links {
+  position: absolute;
+  bottom: 2.5rem;
   left: 50%;
   transform: translateX(-50%);
+  display: flex;
+  gap: 1.25rem;
+  align-items: flex-end;
+  background: rgba(255, 255, 255, 0.82);
+  backdrop-filter: blur(12px);
+  -webkit-backdrop-filter: blur(12px);
+  padding: 0.85rem 1.5rem;
+  border-radius: 999px;
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
+  margin: 0;
+}
+
+.hero-link {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  color: var(--wordmark);
   text-align: center;
-  color: #e5a6c2;
-  width: 100%;
-  pointer-events: none;
+  font-weight: 600;
+  transition: transform 0.2s ease;
 }
 
-/* Mobile refinements */
+.hero-link:focus-visible,
+.hero-link:hover {
+  transform: translateY(-4px);
+}
+
+.hero-img-container {
+  position: static;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  overflow: visible;
+}
+
+.hero-img-container img {
+  width: 72px;
+  height: 72px;
+  border-radius: 999px;
+  object-fit: cover;
+  border: 3px solid var(--nav-color);
+  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
+}
+
+.hero-link-text {
+  font-size: clamp(14px, 2.6vw, 16px);
+  white-space: nowrap;
+}
+
 @media (max-width: 900px) {
-  /* Shrink hero images further so all three can comfortably fit side by side */
-  .hero-link img {
-    width: min(28vw, 100px);
+  .hero {
+    padding-bottom: 8rem;
   }
-}
 
-/* === Final overrides to satisfy user styling === */
-.nav .pill {
-  background: #e5a6c2 !important;
-  border: 2px solid #d4af37 !important;
-  color: #7a0e17 !important;
-  box-shadow: none !important;
-}
-.nav .pill:hover {
-  background: #dca0b8 !important;
-  box-shadow: 0 0 12px #d4af37, inset 0 0 6px rgba(255,255,255,0.6) !important;
-}
-
-/* Center hero labels above images with soft pink color */
-.hero-label.top {
-  position: relative !important;
-  top: -1.2rem !important;
-  left: 50% !important;
-  transform: translateX(-50%) !important;
-  display: block !important;
-  text-align: center !important;
-  color: #e5a6c2 !important;
-
-.
-Soft pink join waitlist
-/* Ensure hero images fit sstyles.css
-ide-by-side on mobile */
-@media (max-width: 900px) {
   .hero-links {
-    display: flex !important;
-    flex-direction: row !important;
-    flex-wrap: wrap !important;
-    justify-content: center !important;
-    gap: 12px !important;
+    position: static;
+    transform: none;
+    margin-top: 1.5rem;
+    border-radius: 32px;
+    flex-wrap: wrap;
+    justify-content: center;
   }
-  .hero-link img {
-    width: min(30vw, 100px) !important;
+
+  .hero-img-container img {
+    width: 64px;
+    height: 64px;
   }
 }

--- a/style.css
+++ b/style.css
@@ -94,18 +94,16 @@ button{font:inherit}
   box-shadow:0 10px 20px rgba(0,0,0,0.2), 0 0 16px rgba(212, 175, 55, 0.6);
 }
 
-/* HERO LAYOUT - new grid with corner cards and high title */
+/* HERO */
 .hero{
-  /* Use a simple single-column grid for hero content and allow absolute/fixed positioned cards to float behind it */
-  position: relative;
-  display: grid;
-  grid-template-columns: 1fr;
-  grid-template-rows: auto auto auto;
-  justify-items: center;
-  align-items: center;
-  min-height: 92svh;
-  /* Move content further upward and allocate more space for the images at the bottom */
-  padding: 4svh 20px 10svh;
+  position:relative;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  justify-content:flex-start;
+  min-height:100svh;
+  padding:clamp(48px,12vh,96px) 20px clamp(160px,26vh,220px);
+  text-align:center;
 }
 
 .hero-bg{
@@ -119,11 +117,17 @@ button{font:inherit}
 }
 
 /* Title group sits high between the top images */
-.title-group{
-  text-align:center;
-  position: relative;
-  z-index: 5;
+.hero-content{
+  position:relative;
+  z-index:5;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:clamp(1rem,2vh,2.4rem);
+  max-width:clamp(320px,80vw,720px);
 }
+
+.title-group{text-align:center;}
 .wordmark{
   color:var(--wordmark);
   /* Use Playfair Display font for the main Golabii wordmark */
@@ -134,13 +138,7 @@ button{font:inherit}
 }
 
 /* Call-to-action and tagline */
-.cta-group{
-  text-align:center;
-  position: relative;
-  z-index: 5;
-  /* Add vertical spacing so the CTA does not collide with the tagline above */
-  margin-top:0.6rem;
-}
+.cta-group{z-index:5;}
 .cta-primary{
   /* Use the gradient for all primary call‑to‑action buttons */
   background:linear-gradient(135deg, var(--cta-gradient-start) 0%, var(--cta-gradient-end) 100%);
@@ -179,31 +177,8 @@ button{font:inherit}
   font-size:clamp(18px,2.5vw,28px);
 }
 
-/* Container for the hero jump links */
-.hero-links{
-  display:flex;
-  gap:1rem;
-  align-items:center;
-  justify-content:center;
-  position:relative;
-  z-index:5;
-}
-
-.hero-link{
-  text-decoration:none;
-}
-
 /* Bottom third message */
-.bottom-notice{
-  text-align:center;
-  position: relative;
-  z-index: 5;
-  /* Slight gap above the bottom notice to separate it from the CTA group.  
-     Keep it similar to the tagline spacing so the pieces feel cohesive. */
-  /* Add space between the CTA and the 'coming soon' notice */
-  /* Move the bottom notice closer to the call‑to‑action to match the proximity of the tagline to the wordmark */
-  margin-top:0.4rem;
-}
+.bottom-notice{text-align:center;z-index:5;}
 .bottom-notice .coming{
   font-size:clamp(20px,2.5vw,28px);
   letter-spacing:.04em;
@@ -229,9 +204,20 @@ button{font:inherit}
 
 /* Previously floating card styles are removed because images are now statically positioned at the bottom of the hero. */
 
-/* OTHER SECTIONS (unchanged) */
-.split{display:grid;grid-template-columns:1.1fr .9fr;gap:28px;align-items:center;padding:64px 20px;max-width:1100px;margin:0 auto}
-.split .visual{justify-self:center}
+/* OTHER SECTIONS */
+.split{
+  display:grid;
+  grid-template-columns:minmax(0,1.1fr) minmax(0,0.9fr);
+  gap:clamp(28px,6vw,64px);
+  align-items:center;
+  padding:64px 20px;
+  max-width:1100px;
+  margin:0 auto;
+  text-align:left;
+}
+.split .copy{display:flex;flex-direction:column;gap:clamp(0.75rem,2vh,1.5rem);}
+.split .visual{justify-self:center;}
+.split .visual img{border-radius:20px;box-shadow:0 16px 32px rgba(0,0,0,0.12);}
 .panel{padding:72px 20px;max-width:900px;margin:0 auto}
 .panel h2{margin:0 0 12px}
 .grid{padding:64px 20px;display:grid;grid-template-columns:repeat(3,1fr);gap:20px;max-width:1100px;margin:0 auto}
@@ -250,14 +236,13 @@ button{font:inherit}
 @media (max-width:900px){
   .nav nav{display:none}
   .burger{display:block}
-  .hero{
-    grid-template-columns: 1fr;
-    grid-template-rows: auto auto auto;
-    gap: 14px;
+  .split{
+    grid-template-columns:1fr;
+    text-align:center;
+    padding:48px 20px;
   }
-  /* On small screens, images fill available width */
-  .card img{width:100%;min-width:0}
-  .split{grid-template-columns:1fr}
+  .split .copy{align-items:center;}
+  .split .visual img{max-width:min(420px,100%);}
   .grid{grid-template-columns:1fr}
 }
 
@@ -284,81 +269,70 @@ button{font:inherit}
 }
 
 /* Hero jump buttons */
-.hero {
-  padding-bottom: 12rem;
+.hero-links{
+  position:absolute;
+  bottom:clamp(24px,4vh,48px);
+  left:50%;
+  transform:translateX(-50%);
+  display:flex;
+  gap:clamp(0.75rem,2vw,1.5rem);
+  padding:clamp(0.65rem,1.5vh,1rem) clamp(1rem,2.5vw,2rem);
+  align-items:flex-end;
+  background:rgba(255,255,255,0.82);
+  backdrop-filter:blur(14px);
+  -webkit-backdrop-filter:blur(14px);
+  border-radius:999px;
+  box-shadow:0 18px 38px rgba(0,0,0,0.18);
+  z-index:6;
 }
 
-.hero-links {
-  position: absolute;
-  bottom: 2.5rem;
-  left: 50%;
-  transform: translateX(-50%);
-  display: flex;
-  gap: 1.25rem;
-  align-items: flex-end;
-  background: rgba(255, 255, 255, 0.82);
-  backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
-  padding: 0.85rem 1.5rem;
-  border-radius: 999px;
-  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
-  margin: 0;
-}
-
-.hero-link {
-  display: inline-flex;
-  flex-direction: column;
-  align-items: center;
-  color: var(--wordmark);
-  text-align: center;
-  font-weight: 600;
-  transition: transform 0.2s ease;
+.hero-link{
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:0.4rem;
+  color:var(--wordmark);
+  font-weight:600;
+  text-align:center;
+  font-size:clamp(14px,1.2vw,16px);
+  text-decoration:none;
+  transition:transform 0.2s ease, color 0.2s ease;
 }
 
 .hero-link:focus-visible,
-.hero-link:hover {
-  transform: translateY(-4px);
+.hero-link:hover{transform:translateY(-4px);color:var(--cta-gradient-end);}
+
+.hero-img-container{
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  width:64px;
+  height:64px;
+  border-radius:50%;
+  padding:3px;
+  background:linear-gradient(135deg,var(--cta-gradient-start),var(--cta-gradient-end));
+  box-shadow:0 10px 20px rgba(0,0,0,0.25);
 }
 
-.hero-img-container {
-  position: static;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  gap: 0.5rem;
-  overflow: visible;
+.hero-img-container img{
+  width:100%;
+  height:100%;
+  border-radius:50%;
+  object-fit:cover;
+  border:3px solid rgba(255,255,255,0.85);
 }
 
-.hero-img-container img {
-  width: 72px;
-  height: 72px;
-  border-radius: 999px;
-  object-fit: cover;
-  border: 3px solid var(--nav-color);
-  box-shadow: 0 8px 16px rgba(0, 0, 0, 0.2);
-}
+.hero-link-text{white-space:nowrap;letter-spacing:0.02em;}
 
-.hero-link-text {
-  font-size: clamp(14px, 2.6vw, 16px);
-  white-space: nowrap;
-}
-
-@media (max-width: 900px) {
-  .hero {
-    padding-bottom: 8rem;
+@media (max-width:900px){
+  .hero{padding-bottom:clamp(120px,24vh,180px);}
+  .hero-links{
+    position:static;
+    transform:none;
+    margin-top:clamp(1rem,3vh,2rem);
+    flex-wrap:wrap;
+    justify-content:center;
+    row-gap:0.75rem;
   }
-
-  .hero-links {
-    position: static;
-    transform: none;
-    margin-top: 1.5rem;
-    border-radius: 32px;
-    flex-wrap: wrap;
-    justify-content: center;
-  }
-
-  .hero-img-container img {
-    width: 64px;
-    height: 64px;
-  }
+  .hero-img-container{width:56px;height:56px;}
 }


### PR DESCRIPTION
## Summary
- replace the hero scroll links with compact jump buttons anchored to the bottom of the hero image
- clean up broken inline overrides and restore the goals section markup so copy and imagery align
- refresh supporting styles, including the nav pill button, hero background image, and responsive behaviour

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_6901c0028dd48328823f6fdf0f5297ea